### PR TITLE
Exclude bounded key selectors from result key selector after bound

### DIFF
--- a/packages/reselect-utils/src/__tests__/createBoundSelector.test.ts
+++ b/packages/reselect-utils/src/__tests__/createBoundSelector.test.ts
@@ -226,13 +226,11 @@ describe('createBoundSelector', () => {
       const { keySelector } = boundSelector;
 
       const key = keySelector(commonState, {
-        value1: 3,
         value2: 2,
-        value3: 5,
-        value4: 6,
+        value3: 3,
       }) as unknown;
 
-      expect(key).toBe('2:5');
+      expect(key).toBe('2:3');
     });
   });
 
@@ -315,7 +313,7 @@ describe('createBoundSelector', () => {
     expect(isComposedKeySelector(keySelector)).toBeFalsy();
   });
 
-  test('should return composed key selector if result key sector has more than one dependency', () => {
+  test('should return composed key selector if result key selector has more than one dependency', () => {
     const firstPropSelector = createPropSelector<{ value1: number }>().value1();
     const secondPropSelector = createPropSelector<{
       value2: number;
@@ -343,7 +341,7 @@ describe('createBoundSelector', () => {
     expect(isComposedKeySelector(keySelector)).toBeTruthy();
   });
 
-  test('should bound not props selector without exclude', () => {
+  test('should bound exotic key selector without exclude', () => {
     const firstPropSelector = (state: State, props: { value1: number }) =>
       props.value1;
     const secondPropSelector = (state: State, props: { value2: number }) =>

--- a/packages/reselect-utils/src/__tests__/createBoundSelector.test.ts
+++ b/packages/reselect-utils/src/__tests__/createBoundSelector.test.ts
@@ -3,9 +3,14 @@ import { commonState, State } from '../__data__/state';
 import { createBoundSelector } from '../createBoundSelector';
 import { createStructuredSelector } from '../createStructuredSelector';
 import { NamedParametricSelector } from '../types';
-import { isCachedSelector } from '../helpers';
+import { defaultKeySelector, isCachedSelector } from '../helpers';
+import { createPropSelector } from '../createPropSelector';
+import {
+  composeKeySelectors,
+  isComposedKeySelector,
+} from '../composeKeySelectors';
 
-describe('createAdaptedSelector', () => {
+describe('createBoundSelector', () => {
   const personSelector = (state: State, props: { personId: number }) =>
     state.persons[props.personId];
   const messageSelector = (state: State, props: { messageId: number }) =>
@@ -185,5 +190,195 @@ describe('createAdaptedSelector', () => {
       ) as unknown;
       expect(key).toBe(1);
     });
+
+    test('should return key without keys which selectors are bounded', () => {
+      const firstPropSelector = createPropSelector<{
+        value1: number;
+      }>().value1();
+      const secondPropSelector = createPropSelector<{
+        value2: number;
+      }>().value2();
+      const thirdPropSelector = createPropSelector<{
+        value3: number;
+      }>().value3();
+      const fourthPropSelector = createPropSelector<{
+        value4: number;
+      }>().value4();
+
+      const selector = createCachedSelector([], () => {})({
+        keySelector: composeKeySelectors(
+          firstPropSelector,
+          secondPropSelector,
+          thirdPropSelector,
+          fourthPropSelector,
+        ),
+      });
+
+      const boundSelector = createBoundSelector(selector, {
+        value1: 1,
+        value4: 4,
+      });
+
+      if (!isCachedSelector(boundSelector)) {
+        throw new Error('selector should be cached');
+      }
+
+      const { keySelector } = boundSelector;
+
+      const key = keySelector(commonState, {
+        value1: 3,
+        value2: 2,
+        value3: 5,
+        value4: 6,
+      }) as unknown;
+
+      expect(key).toBe('2:5');
+    });
+  });
+
+  test('should return default key selector if all selectors are bounded', () => {
+    const firstPropSelector = createPropSelector<{ value1: number }>().value1();
+    const secondPropSelector = createPropSelector<{
+      value2: number;
+    }>().value2();
+
+    const selector = createCachedSelector([], () => {})({
+      keySelector: composeKeySelectors(firstPropSelector, secondPropSelector),
+    });
+
+    const boundSelector = createBoundSelector(selector, {
+      value1: 1,
+      value2: 2,
+    });
+
+    if (!isCachedSelector(boundSelector)) {
+      throw new Error('selector should be cached');
+    }
+
+    const { keySelector } = boundSelector;
+
+    expect(keySelector).toBe(defaultKeySelector);
+  });
+
+  test('should exclude default key selector from result key selector', () => {
+    const firstPropSelector = createPropSelector<{ value1: number }>().value1();
+    const secondPropSelector = createPropSelector<{
+      value2: number;
+    }>().value2();
+
+    const selector = createCachedSelector([], () => {})({
+      keySelector: composeKeySelectors(
+        firstPropSelector,
+        secondPropSelector,
+        defaultKeySelector,
+      ),
+    });
+
+    const boundSelector = createBoundSelector(selector, {
+      value3: 3,
+    });
+
+    if (!isCachedSelector(boundSelector)) {
+      throw new Error('selector should be cached');
+    }
+
+    const { keySelector } = boundSelector;
+
+    const key = keySelector(commonState, {
+      value1: 1,
+      value2: 2,
+    }) as unknown;
+
+    expect(key).toBe('1:2');
+  });
+
+  test('should return not composed key selector if result key sector has only one dependency', () => {
+    const firstPropSelector = createPropSelector<{ value1: number }>().value1();
+    const secondPropSelector = createPropSelector<{
+      value2: number;
+    }>().value2();
+
+    const selector = createCachedSelector([], () => {})({
+      keySelector: composeKeySelectors(firstPropSelector, secondPropSelector),
+    });
+
+    const boundSelector = createBoundSelector(selector, {
+      value1: 1,
+    });
+
+    if (!isCachedSelector(boundSelector)) {
+      throw new Error('selector should be cached');
+    }
+
+    const { keySelector } = boundSelector;
+
+    expect(isComposedKeySelector(keySelector)).toBeFalsy();
+  });
+
+  test('should return composed key selector if result key sector has more than one dependency', () => {
+    const firstPropSelector = createPropSelector<{ value1: number }>().value1();
+    const secondPropSelector = createPropSelector<{
+      value2: number;
+    }>().value2();
+    const thirdPropSelector = createPropSelector<{ value3: number }>().value3();
+
+    const selector = createCachedSelector([], () => {})({
+      keySelector: composeKeySelectors(
+        firstPropSelector,
+        secondPropSelector,
+        thirdPropSelector,
+      ),
+    });
+
+    const boundSelector = createBoundSelector(selector, {
+      value1: 1,
+    });
+
+    if (!isCachedSelector(boundSelector)) {
+      throw new Error('selector should be cached');
+    }
+
+    const { keySelector } = boundSelector;
+
+    expect(isComposedKeySelector(keySelector)).toBeTruthy();
+  });
+
+  test('should bound not props selector without exclude', () => {
+    const firstPropSelector = (state: State, props: { value1: number }) =>
+      props.value1;
+    const secondPropSelector = (state: State, props: { value2: number }) =>
+      props.value2;
+    const thirdPropSelector = (state: State, props: { value3: number }) =>
+      props.value3;
+
+    const selector = createCachedSelector(
+      [firstPropSelector, secondPropSelector, thirdPropSelector],
+      () => {},
+    )({
+      keySelector: composeKeySelectors(
+        firstPropSelector,
+        secondPropSelector,
+        thirdPropSelector,
+      ),
+    });
+
+    const boundSelector = createBoundSelector(selector, {
+      value1: 1,
+      value3: 3,
+    });
+
+    if (!isCachedSelector(boundSelector)) {
+      throw new Error('selector should be cached');
+    }
+
+    const { keySelector } = boundSelector;
+
+    const key = keySelector(commonState, {
+      value1: 10,
+      value2: 20,
+      value3: 30,
+    }) as unknown;
+
+    expect(key).toBe('1:20:3');
   });
 });

--- a/packages/reselect-utils/src/__tests__/helpers.test.ts
+++ b/packages/reselect-utils/src/__tests__/helpers.test.ts
@@ -1,0 +1,69 @@
+import { arePathsEqual, getObjectPaths } from '../helpers';
+
+describe('getObjectPaths', () => {
+  test('should extract keys from object', () => {
+    const obj = {
+      key1: 1,
+      key2: 'sting',
+      key3: true,
+      key4: undefined,
+      key5: null,
+    };
+
+    const actual = getObjectPaths(obj);
+
+    expect(actual).toEqual([['key1'], ['key2'], ['key3'], ['key4'], ['key5']]);
+  });
+
+  test('should extract keys from nested object', () => {
+    const obj = {
+      key1: {
+        key2: {
+          key3: undefined,
+        },
+        key4: {
+          key5: 1,
+        },
+        key6: {
+          key7: 'sting',
+          key8: null,
+        },
+      },
+    };
+
+    const actual = getObjectPaths(obj);
+
+    expect(actual).toEqual([
+      ['key1', 'key6', 'key7'],
+      ['key1', 'key6', 'key8'],
+      ['key1', 'key4', 'key5'],
+      ['key1', 'key2', 'key3'],
+    ]);
+  });
+});
+
+describe('arePathsEqual', () => {
+  test('should return false if paths have different length', () => {
+    const path = ['first', 'second'];
+    const anotherPath = ['123'];
+
+    const actual = arePathsEqual(path, anotherPath);
+    expect(actual).toBeFalsy();
+  });
+
+  test('should return false if paths have different elements', () => {
+    const path = ['first', 'second'];
+    const anotherPath = ['first', 'third'];
+
+    const actual = arePathsEqual(path, anotherPath);
+    expect(actual).toBeFalsy();
+  });
+
+  test('should return true if paths have equal elements', () => {
+    const path = ['first', 'second'];
+    const anotherPath = ['first', 'second'];
+
+    const actual = arePathsEqual(path, anotherPath);
+    expect(actual).toBeTruthy();
+  });
+});

--- a/packages/reselect-utils/src/__tests__/helpers.test.ts
+++ b/packages/reselect-utils/src/__tests__/helpers.test.ts
@@ -34,10 +34,23 @@ describe('getObjectPaths', () => {
     const actual = getObjectPaths(obj);
 
     expect(actual).toEqual([
+      ['key1', 'key2', 'key3'],
+      ['key1', 'key4', 'key5'],
       ['key1', 'key6', 'key7'],
       ['key1', 'key6', 'key8'],
-      ['key1', 'key4', 'key5'],
-      ['key1', 'key2', 'key3'],
+    ]);
+  });
+
+  test('should work with array', () => {
+    const obj = {
+      key1: [{ key2: { key3: [1] } }, 2],
+    };
+
+    const actual = getObjectPaths(obj);
+
+    expect(actual).toEqual([
+      ['key1', '0', 'key2', 'key3', '0'],
+      ['key1', '1'],
     ]);
   });
 });

--- a/packages/reselect-utils/src/composeKeySelectors.ts
+++ b/packages/reselect-utils/src/composeKeySelectors.ts
@@ -2,8 +2,27 @@ import { KeySelector, ParametricKeySelector } from 're-reselect';
 
 const composedKeySelectorSymbol = Symbol.for('ComposedKeySelector');
 
-export const isComposedKeySelector = (selector: unknown) =>
-  selector instanceof Object && composedKeySelectorSymbol in selector;
+export function isComposedKeySelector<S>(
+  keySelector: KeySelector<S>,
+): keySelector is OutputKeySelector<S, KeySelector<S>[]>;
+
+export function isComposedKeySelector<S, P>(
+  keySelector: ParametricKeySelector<S, P>,
+): keySelector is OutputParametricKeySelector<
+  S,
+  P,
+  ParametricKeySelector<S, P>[]
+>;
+
+export function isComposedKeySelector<S, P>(
+  keySelector: KeySelector<S> | ParametricKeySelector<S, P>,
+): keySelector is
+  | OutputKeySelector<S, KeySelector<S>>
+  | OutputParametricKeySelector<S, P, ParametricKeySelector<S, P>[]> {
+  return (
+    'dependencies' in keySelector && composedKeySelectorSymbol in keySelector
+  );
+}
 
 export type OutputKeySelector<S, D> = KeySelector<S> & {
   dependencies: D;

--- a/packages/reselect-utils/src/composingKeySelectorCreator.ts
+++ b/packages/reselect-utils/src/composingKeySelectorCreator.ts
@@ -14,10 +14,7 @@ const areSelectorsEqual = (selector: unknown, another: unknown) => {
   }
 
   if (isPropSelector(selector) && isPropSelector(another)) {
-    const { path: selectorPath } = selector;
-    const { path: anotherPath } = another;
-
-    return arePathsEqual(selectorPath, anotherPath);
+    return arePathsEqual(selector.path, another.path);
   }
 
   return false;

--- a/packages/reselect-utils/src/composingKeySelectorCreator.ts
+++ b/packages/reselect-utils/src/composingKeySelectorCreator.ts
@@ -1,6 +1,6 @@
 import { KeySelector, ParametricKeySelector } from 're-reselect';
 import { isPropSelector } from './createPropSelector';
-import { defaultKeySelector, isCachedSelector } from './helpers';
+import { arePathsEqual, defaultKeySelector, isCachedSelector } from './helpers';
 import {
   composeKeySelectors,
   isComposedKeySelector,
@@ -14,20 +14,10 @@ const areSelectorsEqual = (selector: unknown, another: unknown) => {
   }
 
   if (isPropSelector(selector) && isPropSelector(another)) {
-    const { path: selectorPath } = selector as { path: (string | number)[] };
-    const { path: anotherPath } = another as { path: (string | number)[] };
+    const { path: selectorPath } = selector;
+    const { path: anotherPath } = another;
 
-    if (selectorPath.length !== anotherPath.length) {
-      return false;
-    }
-
-    for (let i = 0; i < selectorPath.length; i += 1) {
-      if (selectorPath[i] !== anotherPath[i]) {
-        return false;
-      }
-    }
-
-    return true;
+    return arePathsEqual(selectorPath, anotherPath);
   }
 
   return false;
@@ -50,7 +40,7 @@ const flatKeySelectors = <S, P>(
   for (let i = 0; i < keySelectors.length; i += 1) {
     const keySelector = keySelectors[i];
 
-    if ('dependencies' in keySelector && isComposedKeySelector(keySelector)) {
+    if (isComposedKeySelector(keySelector)) {
       result.push(...flatKeySelectors(keySelector.dependencies));
     } else {
       result.push(keySelector);
@@ -72,6 +62,22 @@ const uniqKeySelectors = <S, P>(
       areSelectorsEqual(keySelector, resultKeySelector),
     );
     if (!isKeySelectorAdded) {
+      result.push(keySelector);
+    }
+  }
+
+  return result;
+};
+
+export const excludeDefaultSelectors = <S, P>(
+  keySelectors: (KeySelector<S> | ParametricKeySelector<S, P>)[],
+) => {
+  const result: (KeySelector<S> | ParametricKeySelector<S, P>)[] = [];
+
+  for (let i = 0; i < keySelectors.length; i += 1) {
+    const keySelector = keySelectors[i];
+
+    if (keySelector !== defaultKeySelector) {
       result.push(keySelector);
     }
   }
@@ -110,6 +116,7 @@ export function composingKeySelectorCreator<S, P>({
 
   keySelectors = flatKeySelectors(keySelectors);
   keySelectors = uniqKeySelectors(keySelectors);
+  keySelectors = excludeDefaultSelectors(keySelectors);
 
   if (keySelectors.length === 0) {
     return defaultKeySelector;

--- a/packages/reselect-utils/src/createBoundSelector.ts
+++ b/packages/reselect-utils/src/createBoundSelector.ts
@@ -9,7 +9,17 @@ import {
   isDebugMode,
   isCachedSelector,
   defineDynamicSelectorName,
+  defaultKeySelector,
+  isObject,
+  arePathsEqual,
+  getObjectPaths,
 } from './helpers';
+import {
+  composeKeySelectors,
+  isComposedKeySelector,
+} from './composeKeySelectors';
+import { isPropSelector } from './createPropSelector';
+import { excludeDefaultSelectors } from './composingKeySelectorCreator';
 
 const generateBindingName = <P>(binding: P) => {
   const structure = Object.keys(binding).reduce(
@@ -107,10 +117,51 @@ export const createBoundSelector = <
       );
     }
 
-    cachedBoundSelector.keySelector = bindingStrategy(
-      baseSelector.keySelector,
-      binding,
-    );
+    const baseKeySelector = baseSelector.keySelector;
+
+    if (isObject(binding)) {
+      const paths = getObjectPaths(binding);
+      let keySelectors = isComposedKeySelector(baseKeySelector)
+        ? baseKeySelector.dependencies
+        : [baseKeySelector];
+
+      keySelectors = excludeDefaultSelectors(keySelectors);
+
+      keySelectors = keySelectors.filter((keySelector) => {
+        if (isPropSelector(keySelector)) {
+          const { path: selectorPath } = keySelector;
+
+          return paths.every((path) => !arePathsEqual(selectorPath, path));
+        }
+
+        return true;
+      });
+
+      if (keySelectors.length === 0) {
+        cachedBoundSelector.keySelector = defaultKeySelector;
+      } else if (keySelectors.length === 1) {
+        const [keySelector] = keySelectors;
+        cachedBoundSelector.keySelector = keySelector;
+      } else {
+        cachedBoundSelector.keySelector = composeKeySelectors(...keySelectors);
+      }
+
+      const isThereExoticKeySelectors = keySelectors.some(
+        (keySelector) => !isPropSelector(keySelector),
+      );
+
+      if (isThereExoticKeySelectors) {
+        cachedBoundSelector.keySelector = bindingStrategy(
+          cachedBoundSelector.keySelector,
+          binding,
+        );
+      }
+    } else {
+      cachedBoundSelector.keySelector = bindingStrategy(
+        baseKeySelector,
+        binding,
+      );
+    }
   }
 
   return boundSelector;

--- a/packages/reselect-utils/src/createBoundSelector.ts
+++ b/packages/reselect-utils/src/createBoundSelector.ts
@@ -127,15 +127,17 @@ export const createBoundSelector = <
 
       keySelectors = excludeDefaultSelectors(keySelectors);
 
-      keySelectors = keySelectors.filter((keySelector) => {
-        if (isPropSelector(keySelector)) {
-          const { path: selectorPath } = keySelector;
-
-          return paths.every((path) => !arePathsEqual(selectorPath, path));
-        }
-
-        return true;
-      });
+      keySelectors = keySelectors
+        .filter(
+          (keySelector) =>
+            !isPropSelector(keySelector) ||
+            !paths.some((path) => arePathsEqual(keySelector.path, path)),
+        )
+        .map((keySelector) =>
+          isPropSelector(keySelector)
+            ? keySelector
+            : bindingStrategy(keySelector, binding),
+        );
 
       if (keySelectors.length === 0) {
         cachedBoundSelector.keySelector = defaultKeySelector;
@@ -144,17 +146,6 @@ export const createBoundSelector = <
         cachedBoundSelector.keySelector = keySelector;
       } else {
         cachedBoundSelector.keySelector = composeKeySelectors(...keySelectors);
-      }
-
-      const isThereExoticKeySelectors = keySelectors.some(
-        (keySelector) => !isPropSelector(keySelector),
-      );
-
-      if (isThereExoticKeySelectors) {
-        cachedBoundSelector.keySelector = bindingStrategy(
-          cachedBoundSelector.keySelector,
-          binding,
-        );
       }
     } else {
       cachedBoundSelector.keySelector = bindingStrategy(

--- a/packages/reselect-utils/src/createPathSelector.ts
+++ b/packages/reselect-utils/src/createPathSelector.ts
@@ -4,6 +4,7 @@ import {
   defineDynamicSelectorName,
   getSelectorName,
   isDebugMode,
+  isObject,
 } from './helpers';
 
 export type Defined<T> = Exclude<T, undefined>;
@@ -186,9 +187,6 @@ export type OptionalPathParametricSelectorType<
 > = OptionalParametricSelectorBuilder<S, P, R, D> &
   OptionalDataParametricSelectorWrapper<S, P, NonNullable<R>, D>;
 
-const isObject = (value: unknown) =>
-  value !== null && typeof value === 'object';
-
 /** @internal */
 export const innerCreatePathSelector = (
   baseSelector: (...args: unknown[]) => unknown,
@@ -206,7 +204,7 @@ export const innerCreatePathSelector = (
       );
 
       for (let i = 0; i < path.length && isObject(result); i += 1) {
-        result = (result as Record<string, unknown>)[path[i]];
+        result = result[path[i]];
       }
 
       return result ?? defaultValue;

--- a/packages/reselect-utils/src/createPathSelector.ts
+++ b/packages/reselect-utils/src/createPathSelector.ts
@@ -1,5 +1,5 @@
 import { Selector, ParametricSelector } from 'reselect';
-import { NamedSelector, NamedParametricSelector } from './types';
+import { NamedSelector, NamedParametricSelector, Path } from './types';
 import {
   defineDynamicSelectorName,
   getSelectorName,
@@ -19,7 +19,7 @@ export type IsOptional<T> = undefined extends T
 export type IsObject<T> = T extends object ? true : false;
 
 export type PathSelector<S, R, D> = NamedSelector<S, R, D> & {
-  path: (string | number)[];
+  path: Path;
 };
 
 export type PathParametricSelector<S, P, R, D> = NamedParametricSelector<
@@ -28,7 +28,7 @@ export type PathParametricSelector<S, P, R, D> = NamedParametricSelector<
   R,
   D
 > & {
-  path: (string | number)[];
+  path: Path;
 };
 
 export type RequiredSelectorBuilder<S, R, D> = () => PathSelector<S, R, D>;
@@ -190,7 +190,7 @@ export type OptionalPathParametricSelectorType<
 /** @internal */
 export const innerCreatePathSelector = (
   baseSelector: (...args: unknown[]) => unknown,
-  path: (string | number)[] = [],
+  path: Path = [],
   applyMeta: (selector: unknown) => void = () => {},
 ): unknown => {
   const proxyTarget = (defaultValue?: unknown) => {
@@ -232,7 +232,7 @@ export const innerCreatePathSelector = (
 
   return new Proxy(proxyTarget, {
     get: (target, key: string | number) =>
-      innerCreatePathSelector(baseSelector, [...path, key], applyMeta),
+      innerCreatePathSelector(baseSelector, [...path, String(key)], applyMeta),
   });
 };
 

--- a/packages/reselect-utils/src/createPropSelector.ts
+++ b/packages/reselect-utils/src/createPropSelector.ts
@@ -3,12 +3,11 @@ import {
   innerCreatePathSelector,
   RequiredPathParametricSelectorType,
 } from './createPathSelector';
+import { Path } from './types';
 
 const propSelectorSymbol = Symbol.for('PropSelector');
 
-export const isPropSelector = (
-  selector: unknown,
-): selector is { path: (string | number)[] } =>
+export const isPropSelector = (selector: unknown): selector is { path: Path } =>
   selector instanceof Object && propSelectorSymbol in selector;
 
 export function createPropSelector<P>(): RequiredPathParametricSelectorType<

--- a/packages/reselect-utils/src/createPropSelector.ts
+++ b/packages/reselect-utils/src/createPropSelector.ts
@@ -6,7 +6,9 @@ import {
 
 const propSelectorSymbol = Symbol.for('PropSelector');
 
-export const isPropSelector = (selector: unknown) =>
+export const isPropSelector = (
+  selector: unknown,
+): selector is { path: (string | number)[] } =>
   selector instanceof Object && propSelectorSymbol in selector;
 
 export function createPropSelector<P>(): RequiredPathParametricSelectorType<

--- a/packages/reselect-utils/src/helpers.ts
+++ b/packages/reselect-utils/src/helpers.ts
@@ -39,3 +39,62 @@ export const isDebugMode = () => debugMode;
 export const setDebugMode = (value: boolean) => {
   debugMode = value;
 };
+
+export const isObject = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object';
+
+export const arePathsEqual = (
+  path: (string | number)[],
+  anotherPath: (string | number)[],
+) => {
+  if (path.length !== anotherPath.length) {
+    return false;
+  }
+
+  for (let i = 0; i < path.length; i += 1) {
+    if (path[i] !== anotherPath[i]) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+interface Node {
+  obj: Record<string, unknown>;
+  path: string[];
+}
+
+export const getObjectPaths = (obj: Record<string, unknown>) => {
+  const paths: string[][] = [];
+  const nodes: Node[] = [
+    {
+      obj,
+      path: [],
+    },
+  ];
+
+  while (nodes.length > 0) {
+    const node = nodes.pop();
+
+    if (node) {
+      const keys = Object.keys(node.obj);
+
+      for (let i = 0; i < keys.length; i += 1) {
+        const key = keys[i];
+        const value = node.obj[key];
+        const path = node.path.concat(key);
+
+        if (isObject(value)) {
+          nodes.push({
+            obj: value,
+            path,
+          });
+        } else {
+          paths.push(path);
+        }
+      }
+    }
+  }
+  return paths;
+};

--- a/packages/reselect-utils/src/helpers.ts
+++ b/packages/reselect-utils/src/helpers.ts
@@ -1,4 +1,4 @@
-import { CachedSelector } from './types';
+import { CachedSelector, Path } from './types';
 
 export const getSelectorName = (selector: {
   name: string;
@@ -43,10 +43,7 @@ export const setDebugMode = (value: boolean) => {
 export const isObject = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === 'object';
 
-export const arePathsEqual = (
-  path: (string | number)[],
-  anotherPath: (string | number)[],
-) => {
+export const arePathsEqual = (path: Path, anotherPath: Path) => {
   if (path.length !== anotherPath.length) {
     return false;
   }
@@ -60,41 +57,14 @@ export const arePathsEqual = (
   return true;
 };
 
-interface Node {
-  obj: Record<string, unknown>;
-  path: string[];
-}
+export const getObjectPaths = (
+  value: unknown,
+  parentPath: Path = [],
+): Path[] => {
+  if (!isObject(value)) return [parentPath];
 
-export const getObjectPaths = (obj: Record<string, unknown>) => {
-  const paths: string[][] = [];
-  const nodes: Node[] = [
-    {
-      obj,
-      path: [],
-    },
-  ];
-
-  while (nodes.length > 0) {
-    const node = nodes.pop();
-
-    if (node) {
-      const keys = Object.keys(node.obj);
-
-      for (let i = 0; i < keys.length; i += 1) {
-        const key = keys[i];
-        const value = node.obj[key];
-        const path = node.path.concat(key);
-
-        if (isObject(value)) {
-          nodes.push({
-            obj: value,
-            path,
-          });
-        } else {
-          paths.push(path);
-        }
-      }
-    }
-  }
-  return paths;
+  return Object.keys(value).reduce<Path[]>((result, key) => {
+    const paths = getObjectPaths(value[key], parentPath.concat([key]));
+    return result.concat(paths);
+  }, []);
 };

--- a/packages/reselect-utils/src/types.ts
+++ b/packages/reselect-utils/src/types.ts
@@ -44,3 +44,5 @@ export type ReReselectSelector =
 
 export type CachedSelector = Pick<ReReselectSelector, 'cache' | 'keySelector'> &
   Partial<ReReselectSelector>;
+
+export type Path = string[];


### PR DESCRIPTION
We can use only objects for `createBoundSelector` otherwise it's meaningless and we have to think about this case. If binding is object we can extract all possible paths which we want to bound. These paths help us to remove bounded key selectors from result key selector. 

**NOTE 1**: If `baseKeySelector` has dependencies which aren't `createPropSelector` we can't exclude them although some of they can be bounded.

**NOTE 2**: This optimization works with conjunction `composingKeySelectorCreator` because all dependencies are flat and uniq.
